### PR TITLE
Fix MCP tool contract and long-answer workflow

### DIFF
--- a/README.AI.md
+++ b/README.AI.md
@@ -166,13 +166,24 @@ Run:
 
 ```bash
 cd /ABSOLUTE/PATH/openevidence-mcp
+npm test
+npm run build
+npm run check
 npm run smoke
 ```
 
 Then MCP-side checks:
 - `oe_auth_status`
 - `oe_history_list`
-- `oe_ask`
+- `oe_article_get` when an article ID is available
+- `oe_ask` with `wait_for_completion=false` for long questions
+- `oe_article_wait` with the returned `article_id`
+
+Agent workflow notes:
+- Use `oe_auth_status` before other tools when auth state is unknown.
+- Use `original_article_id` only for true follow-up continuity; omit it for fresh questions.
+- Treat OpenEvidence output as evidence-research context, not medical advice, diagnosis, or clinical orders.
+- Never expose cookies, storage-state files, tokens, account identifiers, screenshots with private data, or patient-identifiable information.
 
 ## Step 6: Recovery Paths
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ OpenEvidence MCP runs a local stdio MCP server that lets MCP clients use your ex
 - checking whether the saved session is authenticated;
 - listing your OpenEvidence question/article history;
 - fetching a full article payload by ID;
-- asking an OpenEvidence research question and optionally waiting for completion.
+- asking an OpenEvidence research question and optionally waiting for completion;
+- polling an existing OpenEvidence article until it completes.
 
 No official OpenEvidence API token is required.
 
@@ -86,8 +87,22 @@ Other MCP-compatible hosts may work as well, but the examples in this repository
 | --- | --- | --- | --- |
 | `oe_auth_status` | Checks whether the saved OpenEvidence browser session is authenticated. | Yes, saved session file must exist. | None. |
 | `oe_history_list` | Lists prior OpenEvidence articles/questions with optional pagination and search. | Yes. | None. |
-| `oe_article_get` | Fetches a full OpenEvidence article payload by article ID. | Yes. | None. |
+| `oe_article_get` | Fetches an article by ID and returns normalized fields (`status`, `is_complete`, `question`, `answer_text`) plus the raw payload. | Yes. | None. |
+| `oe_article_wait` | Waits for an existing article ID to complete; useful after non-blocking `oe_ask`. | Yes. | None. |
 | `oe_ask` | Creates an OpenEvidence research question and optionally waits for the article to complete. | Yes. | Creates a question/article in your OpenEvidence account. |
+
+## Agent Tool-Calling Notes
+
+The MCP server includes built-in instructions and a prompt named `openevidence_research_workflow` for clients that expose MCP prompts.
+
+Recommended agent workflow:
+
+1. Call `oe_auth_status` when auth state is unknown.
+2. Use `oe_history_list` only when the user wants prior OpenEvidence work or an article ID.
+3. Use `oe_article_get` when you already have an article ID.
+4. For long research questions, call `oe_ask` with `wait_for_completion=false`, then call `oe_article_wait` with the returned `article_id`.
+5. Use `original_article_id` only for true follow-up continuity. Omit it for fresh questions to avoid stale thread context.
+6. Treat outputs as evidence-research context, not medical advice, diagnosis, or clinical orders.
 
 Related commands:
 
@@ -249,6 +264,14 @@ Expected result with a valid session:
 If smoke fails with an auth error, run `npm run login` again. Smoke requires a real OpenEvidence account session and will not pass in a clean CI environment unless session state is provided securely.
 
 By default, smoke output redacts account and history content. Use `npm run smoke -- --verbose` only in a private terminal if raw account/history payloads are needed for debugging.
+
+Developer checks:
+
+```bash
+npm test
+npm run build
+npm run check
+```
 
 ## Security Notes
 

--- a/docs/AGENT_INSTALL_PROMPT.md
+++ b/docs/AGENT_INSTALL_PROMPT.md
@@ -24,7 +24,7 @@ Steps:
 1. Detect my OS and shell.
 2. Check `node --version`, `npm --version`, and `git --version`.
 3. If the repo is missing, clone it. If it exists, pull the latest `main`.
-4. Run `npm ci`, `npx playwright install chromium`, `npm run build`, and `npm run check`.
+4. Run `npm ci`, `npx playwright install chromium`, `npm test`, `npm run build`, and `npm run check`.
 5. Configure OpenEvidence MCP for my current client:
    - Codex: add `[mcp_servers.openevidence]` to the active Codex config TOML.
    - Claude Desktop / Claude app: add `mcpServers.openevidence` to `claude_desktop_config.json`.
@@ -36,6 +36,7 @@ Steps:
 7. Run `npm run smoke`.
 8. If smoke succeeds, tell me to restart my MCP client session/app and verify the OpenEvidence tools appear.
 9. If smoke fails, summarize the error without exposing private data and suggest the next safe fix.
+10. For long OpenEvidence questions after setup, prefer `oe_ask` with `wait_for_completion=false`, then use `oe_article_wait` with the returned `article_id`.
 
 Expected result:
 - `npm run smoke` returns `ok: true` and `authenticated: true`.
@@ -45,5 +46,5 @@ Expected result:
 ## Short Version
 
 ```text
-Install OpenEvidence MCP from https://github.com/bakhtiersizhaev/openevidence-mcp, build it, configure it in my MCP client using an absolute path to `dist/server.js`, guide me through `npm run login`, use `npm run login:browser` if Google blocks Playwright login, then run `npm run smoke`. Do not ask for or expose cookies, tokens, storage-state files, passwords, screenshots with private account data, or patient data. Do not bypass access controls.
+Install OpenEvidence MCP from https://github.com/bakhtiersizhaev/openevidence-mcp, run `npm test`, build it, configure it in my MCP client using an absolute path to `dist/server.js`, guide me through `npm run login`, use `npm run login:browser` if Google blocks Playwright login, then run `npm run smoke`. Do not ask for or expose cookies, tokens, storage-state files, passwords, screenshots with private account data, or patient data. Do not bypass access controls.
 ```

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -113,11 +113,21 @@ Upgrade Node if `node --version` reports a version below 20.
 
 OpenEvidence requests can fail because of network issues, VPN/proxy behavior, account state, or service changes. Retry after confirming you can access OpenEvidence in a normal browser with your own account.
 
-For `oe_ask`, you can lower or raise wait behavior from the MCP call parameters:
+For long `oe_ask` calls, prefer the non-blocking flow:
+
+1. Call `oe_ask` with `wait_for_completion=false`.
+2. Copy the returned `article_id`.
+3. Call `oe_article_wait` with that `article_id`.
+
+This avoids MCP host/client timeouts while OpenEvidence finishes the article.
+
+You can tune wait behavior from the MCP call parameters:
 
 - `wait_for_completion`
 - `timeout_sec`
 - `poll_interval_ms`
+
+If a follow-up unexpectedly returns stale context from a large prior thread, ask a fresh question without `original_article_id`.
 
 ## OpenEvidence UI or API Changed
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "login": "tsx src/login.ts",
     "login:browser": "tsx src/login-browser.ts",
     "check": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx --test \"tests/**/*.test.ts\"",
     "smoke": "tsx src/smoke.ts"
   },
   "files": [

--- a/src/article.ts
+++ b/src/article.ts
@@ -1,0 +1,122 @@
+const PENDING_STATUSES = new Set([
+  "queued",
+  "pending",
+  "processing",
+  "running",
+  "in_progress",
+]);
+
+export type AnswerSource =
+  | "article.output.text"
+  | "article.output.raw_text"
+  | "article.partial_output.text"
+  | "article.partial_output.raw_text"
+  | "inputs.history.outputText";
+
+export interface ExtractedAnswer {
+  text: string;
+  source: AnswerSource;
+}
+
+export interface ArticleStatusInfo {
+  status: string | null;
+  is_complete: boolean;
+}
+
+export interface NormalizedArticleResult {
+  article_id: string | null;
+  status: string | null;
+  is_complete: boolean;
+  question: string | null;
+  answer_text: string | null;
+  answer_source: AnswerSource | null;
+  article: Record<string, unknown>;
+}
+
+export function extractAnswerText(article: Record<string, unknown>): ExtractedAnswer | null {
+  const currentOutput = readObject(article.output);
+  const outputText = readNonEmptyString(currentOutput?.text);
+  if (outputText) {
+    return { text: outputText, source: "article.output.text" };
+  }
+
+  const outputRawText = readNonEmptyString(currentOutput?.raw_text);
+  if (outputRawText) {
+    return { text: outputRawText, source: "article.output.raw_text" };
+  }
+
+  const partialOutput = readObject(article.partial_output);
+  const partialText = readNonEmptyString(partialOutput?.text);
+  if (partialText) {
+    return { text: partialText, source: "article.partial_output.text" };
+  }
+
+  const partialRawText = readNonEmptyString(partialOutput?.raw_text);
+  if (partialRawText) {
+    return { text: partialRawText, source: "article.partial_output.raw_text" };
+  }
+
+  const inputs = readObject(article.inputs);
+  const history = Array.isArray(inputs?.history) ? inputs.history : [];
+  for (let index = history.length - 1; index >= 0; index -= 1) {
+    const item = readObject(history[index]);
+    const historyOutput = readNonEmptyString(item?.outputText);
+    if (historyOutput) {
+      return { text: historyOutput, source: "inputs.history.outputText" };
+    }
+  }
+
+  return null;
+}
+
+export function getArticleStatusInfo(article: Record<string, unknown>): ArticleStatusInfo {
+  const status = readNonEmptyString(article.status)?.toLowerCase() ?? null;
+  return {
+    status,
+    is_complete: status !== null && !PENDING_STATUSES.has(status),
+  };
+}
+
+export function normalizeArticleResult(article: Record<string, unknown>): NormalizedArticleResult {
+  const extracted = extractAnswerText(article);
+  const statusInfo = getArticleStatusInfo(article);
+  return {
+    article_id: readNonEmptyString(article.id),
+    status: statusInfo.status,
+    is_complete: statusInfo.is_complete,
+    question: readQuestion(article),
+    answer_text: extracted?.text ?? null,
+    answer_source: extracted?.source ?? null,
+    article,
+  };
+}
+
+function readQuestion(article: Record<string, unknown>): string | null {
+  const directQuestion =
+    readNonEmptyString(article.question) ??
+    readNonEmptyString(article.input) ??
+    readNonEmptyString(article.inputText) ??
+    readNonEmptyString(article.query) ??
+    readNonEmptyString(article.prompt);
+  if (directQuestion) {
+    return directQuestion;
+  }
+
+  const inputs = readObject(article.inputs);
+  return readNonEmptyString(inputs?.question);
+}
+
+function readObject(value: unknown): Record<string, unknown> | null {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+function readNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/src/login-browser.ts
+++ b/src/login-browser.ts
@@ -9,7 +9,7 @@ import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 
-import { chromium, request } from "playwright";
+import { chromium, type BrowserContext } from "playwright";
 
 import { ensureConfigDirs, resolveConfig } from "./config.js";
 
@@ -47,10 +47,16 @@ async function main() {
     );
 
     await waitForEnter("Press Enter when OpenEvidence login is done...");
-    await saveStorageStateFromBrowser(port, config.authStatePath);
-    await verifyStateFile(config.baseUrl, config.authStatePath);
+    const verified = await saveStorageStateFromBrowser(port, config.authStatePath);
     output.write(`[openevidence-mcp] auth state saved: ${config.authStatePath}\n`);
-    output.write(`[openevidence-mcp] success. You can now run: npm run smoke\n`);
+    if (verified) {
+      output.write(`[openevidence-mcp] browser session looked authenticated.\n`);
+    } else {
+      output.write(
+        `[openevidence-mcp] warning: browser-side auth verification did not complete. Run npm run smoke next.\n`,
+      );
+    }
+    output.write(`[openevidence-mcp] next: npm run smoke\n`);
   } finally {
     child.kill();
   }
@@ -164,7 +170,10 @@ function launchBrowser(
   });
 }
 
-async function saveStorageStateFromBrowser(port: number, authStatePath: string): Promise<void> {
+async function saveStorageStateFromBrowser(
+  port: number,
+  authStatePath: string,
+): Promise<boolean> {
   const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
   try {
     const context = browser.contexts()[0];
@@ -172,8 +181,10 @@ async function saveStorageStateFromBrowser(port: number, authStatePath: string):
       throw new Error("No browser context found. Keep the launched browser window open before pressing Enter.");
     }
 
+    const verified = await looksLoggedIn(context);
     await mkdir(path.dirname(authStatePath), { recursive: true });
     await context.storageState({ path: authStatePath });
+    return verified;
   } finally {
     await browser.close();
   }
@@ -188,24 +199,22 @@ async function waitForEnter(prompt: string): Promise<void> {
   }
 }
 
-async function verifyStateFile(baseUrl: string, statePath: string): Promise<void> {
-  const ctx = await request.newContext({
-    baseURL: baseUrl,
-    storageState: statePath,
-  });
-  try {
-    const check = await ctx.get("/api/auth/me");
-    if (check.status() !== 200) {
-      const body = await check.text();
-      throw new Error(`Auth check failed (${check.status()}): ${body.slice(0, 300)}`);
-    }
-  } finally {
-    await ctx.dispose();
-  }
+async function looksLoggedIn(context: BrowserContext): Promise<boolean> {
+  const cookies = await context.cookies();
+  return cookies.some((cookie) => cookie.name.startsWith("appSession"));
+}
+
+function sanitizeErrorMessage(message: string): string {
+  const firstLine = message.split(/\r?\n/)[0]?.trim() ?? "";
+  return firstLine
+    .replace(/cookie:\s*.*/i, "cookie: [redacted]")
+    .replace(/authorization:\s*.*/i, "authorization: [redacted]")
+    .replace(/bearer\s+[A-Za-z0-9._~+/=-]+/gi, "bearer [redacted]")
+    .slice(0, 300);
 }
 
 main().catch((error) => {
-  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  const message = error instanceof Error ? sanitizeErrorMessage(error.message) : "Unknown error.";
   output.write(`[openevidence-mcp] failed: ${message}\n`);
   output.write(
     [

--- a/src/openevidence-client.ts
+++ b/src/openevidence-client.ts
@@ -2,6 +2,7 @@ import { access } from "node:fs/promises";
 import { constants } from "node:fs";
 import { request, type APIRequestContext } from "playwright";
 
+import { extractAnswerText as extractArticleAnswerText } from "./article.js";
 import type { AppConfig } from "./config.js";
 import type { AuthStatusResult, OpenEvidenceAskRequest, WaitOptions } from "./types.js";
 
@@ -39,7 +40,16 @@ export class OpenEvidenceClient {
       };
     }
 
-    const user = (await res.json()) as Record<string, unknown>;
+    const user = await readJsonObject(res);
+    if (!user) {
+      return {
+        authenticated: false,
+        statusCode,
+        message:
+          "OpenEvidence auth endpoint did not return JSON. Session may be expired, redirected, or blocked. Run login flow.",
+      };
+    }
+
     return {
       authenticated: true,
       statusCode,
@@ -157,21 +167,28 @@ async function assertJsonResponse(status: number, url: string): Promise<void> {
   throw new Error(`GET ${url} failed with status ${status}`);
 }
 
+async function readJsonObject(res: { headers(): Record<string, string>; json(): Promise<unknown> }) {
+  const contentType = res.headers()["content-type"] ?? "";
+  if (!contentType.toLowerCase().includes("application/json")) {
+    return null;
+  }
+
+  try {
+    const data = await res.json();
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      return data as Record<string, unknown>;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 export function extractAnswerText(article: Record<string, unknown>): string | null {
-  const history = article.inputs as Record<string, unknown> | undefined;
-  const historyItems = Array.isArray(history?.history) ? history.history : [];
-  if (historyItems.length === 0) {
-    return null;
-  }
-
-  const last = historyItems[historyItems.length - 1] as Record<string, unknown>;
-  const raw = typeof last.outputText === "string" ? last.outputText : null;
-  if (!raw) {
-    return null;
-  }
-  return raw;
+  return extractArticleAnswerText(article)?.text ?? null;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
+import { normalizeArticleResult } from "./article.js";
 import { ensureConfigDirs, resolveConfig } from "./config.js";
 import { extractAnswerText, OpenEvidenceClient } from "./openevidence-client.js";
 import type { OpenEvidenceAskRequest } from "./types.js";
@@ -15,7 +16,48 @@ ensureConfigDirs(config);
 const server = new McpServer({
   name: "openevidence-mcp",
   version: "1.0.0",
+}, {
+  instructions: [
+    "OpenEvidence MCP is an unofficial local stdio bridge to the user's own authenticated OpenEvidence browser session.",
+    "Use oe_auth_status first when authentication state is unknown.",
+    "Use oe_history_list to find recent OpenEvidence article IDs, and oe_article_get to fetch an existing article.",
+    "Use oe_ask only for OpenEvidence evidence-research questions. Do not present outputs as medical advice, diagnosis, or clinical orders.",
+    "For long research questions, prefer oe_ask with wait_for_completion=false, then call oe_article_wait or oe_article_get with the returned article_id. Some MCP hosts time out long blocking calls.",
+    "Use original_article_id only when the user explicitly wants follow-up continuity in that OpenEvidence thread. For fresh questions, omit original_article_id to avoid stale thread context.",
+    "Never ask for or expose passwords, cookies, storage-state files, session tokens, account identifiers, screenshots with private account data, or patient-identifiable information.",
+  ].join(" "),
 });
+
+server.registerPrompt(
+  "openevidence_research_workflow",
+  {
+    title: "OpenEvidence Research Workflow",
+    description:
+      "Guide an AI agent through safe OpenEvidence MCP usage: auth check, history lookup, fresh question vs follow-up, non-blocking ask, polling, and privacy constraints.",
+  },
+  () => ({
+    messages: [
+      {
+        role: "user" as const,
+        content: {
+          type: "text" as const,
+          text: [
+            "Use OpenEvidence MCP safely with the user's own authenticated OpenEvidence session.",
+            "",
+            "Workflow:",
+            "1. Call oe_auth_status if auth state is unknown.",
+            "2. Call oe_history_list only when the user asks to inspect prior OpenEvidence work or needs an article_id.",
+            "3. Call oe_article_get when you already have an article_id and need the current status or answer_text.",
+            "4. For a new evidence-research question, call oe_ask. For long questions, set wait_for_completion=false and then call oe_article_wait with the returned article_id.",
+            "5. Use original_article_id only for a true follow-up in the same OpenEvidence thread. Omit it for fresh questions or when prior thread context may be stale.",
+            "6. Treat OpenEvidence output as research context, not medical advice, diagnosis, or a clinical order.",
+            "7. Never expose passwords, cookies, storage-state files, session tokens, account identifiers, screenshots with private data, or patient-identifiable information.",
+          ].join("\n"),
+        },
+      },
+    ],
+  }),
+);
 
 server.registerTool(
   "oe_auth_status",
@@ -23,6 +65,10 @@ server.registerTool(
     title: "OpenEvidence Auth Status",
     description:
       "Check whether the saved OpenEvidence browser session is authenticated. Use before history/article/ask tools when auth state is unknown. Returns authenticated=true/false and basic account metadata when available. Requires local session state. No side effects. Can fail if session state is missing, expired, or network access fails.",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
   },
   async () =>
     withClient(async (client) => {
@@ -37,6 +83,10 @@ server.registerTool(
     title: "OpenEvidence History List",
     description:
       "List prior OpenEvidence articles/questions from the authenticated account. Use to find recent research threads or article IDs. Inputs: limit, offset, optional search. Returns the OpenEvidence history payload. Requires authenticated session. No side effects. Can fail on expired auth, network errors, or OpenEvidence endpoint changes.",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: z.object({
       limit: z.number().int().min(1).max(100).default(20).optional(),
       offset: z.number().int().min(0).default(0).optional(),
@@ -55,7 +105,11 @@ server.registerTool(
   {
     title: "OpenEvidence Article Get",
     description:
-      "Fetch a full OpenEvidence article payload by article_id. Use after history lookup or oe_ask returns an article ID. Input: article_id UUID. Returns article data plus extracted_answer_raw when available. Requires authenticated session. No side effects. Can fail on expired auth, network errors, invalid/unknown ID, or endpoint changes.",
+      "Fetch a full OpenEvidence article payload by article_id. Use after history lookup or oe_ask returns an article ID. Input: article_id UUID. Returns normalized fields including status, is_complete, question, answer_text, answer_source, plus raw article data. Requires authenticated session. No side effects. Can fail on expired auth, network errors, invalid/unknown ID, or endpoint changes.",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
     inputSchema: z.object({
       article_id: z.string().uuid(),
     }),
@@ -64,7 +118,36 @@ server.registerTool(
     withClient(async (client) => {
       const article = await client.getArticle(args.article_id);
       return ok({
-        article,
+        ...normalizeArticleResult(article),
+        extracted_answer_raw: extractAnswerText(article),
+      });
+    }),
+);
+
+server.registerTool(
+  "oe_article_wait",
+  {
+    title: "OpenEvidence Article Wait",
+    description:
+      "Wait for an existing OpenEvidence article_id to finish, then return normalized article fields and raw article data. Use after oe_ask with wait_for_completion=false, especially for long research questions that may exceed MCP host timeouts. Inputs: article_id UUID, optional timeout_sec and poll_interval_ms. Requires authenticated session. No side effects. Can return is_complete=false on timeout.",
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      article_id: z.string().uuid(),
+      timeout_sec: z.number().int().min(5).max(900).default(180).optional(),
+      poll_interval_ms: z.number().int().min(300).max(10000).default(1200).optional(),
+    }),
+  },
+  async (args) =>
+    withClient(async (client) => {
+      const article = await client.waitForArticle(args.article_id, {
+        timeoutMs: (args.timeout_sec ?? 180) * 1000,
+        intervalMs: args.poll_interval_ms ?? config.pollIntervalMs,
+      });
+      return ok({
+        ...normalizeArticleResult(article),
         extracted_answer_raw: extractAnswerText(article),
       });
     }),
@@ -75,7 +158,11 @@ server.registerTool(
   {
     title: "OpenEvidence Ask",
     description:
-      "Create an OpenEvidence research question, not medical advice or patient-specific diagnosis. Use for evidence-research questions with the user's own authenticated session. Inputs include question, optional original_article_id, wait/polling controls, and OpenEvidence article options. Returns created article data, article_id, and optionally completed article/extracted answer; may return pending result when not waiting or on timeout. Side effect: creates a question/article in the user's OpenEvidence account. Can fail on expired auth, network timeout, invalid follow-up ID, or endpoint changes.",
+      "Create an OpenEvidence research question, not medical advice or patient-specific diagnosis. For long questions, prefer wait_for_completion=false and then call oe_article_wait with the returned article_id. Use original_article_id only for true follow-up continuity; omit it for fresh questions. Returns created article data, article_id, and optionally normalized completed article fields. Side effect: creates a question/article in the user's OpenEvidence account. Can fail on expired auth, network timeout, invalid follow-up ID, or endpoint changes.",
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+    },
     inputSchema: z.object({
       question: z.string().min(3).max(6000),
       original_article_id: z.string().uuid().optional(),
@@ -121,7 +208,7 @@ server.registerTool(
 
       return ok({
         created,
-        article,
+        ...normalizeArticleResult(article),
         article_id: articleId,
         extracted_answer_raw: extractAnswerText(article),
       });

--- a/src/smoke.ts
+++ b/src/smoke.ts
@@ -14,7 +14,8 @@ async function main() {
     await client.init();
     const auth = await client.getAuthStatus();
     if (!auth.authenticated) {
-      throw new Error(`Not authenticated. Status=${auth.statusCode}`);
+      const detail = auth.message ? ` ${auth.message}` : "";
+      throw new Error(`Not authenticated. Status=${auth.statusCode}.${detail}`);
     }
 
     const history = await client.listHistory(3, 0);
@@ -71,7 +72,7 @@ function redactHistoryItem(item: unknown) {
   };
 
   return {
-    id: typeof record.id === "string" ? record.id : undefined,
+    id_present: typeof record.id === "string" && record.id.length > 0,
     status: typeof record.status === "string" ? record.status : undefined,
     article_type: typeof record.article_type === "string" ? record.article_type : undefined,
     title_present: typeof record.title === "string" && record.title.length > 0,

--- a/tests/article-normalize.test.ts
+++ b/tests/article-normalize.test.ts
@@ -1,0 +1,122 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractAnswerText,
+  getArticleStatusInfo,
+  normalizeArticleResult,
+} from "../src/article.js";
+
+test("extractAnswerText prefers current article output over history fallback", () => {
+  const article = {
+    id: "00000000-0000-4000-8000-000000000001",
+    status: "success",
+    output: {
+      text: "Current synthetic answer.",
+    },
+    inputs: {
+      history: [
+        {
+          outputText: "Stale synthetic history answer.",
+        },
+      ],
+    },
+  };
+
+  const extracted = extractAnswerText(article);
+
+  assert.deepEqual(extracted, {
+    text: "Current synthetic answer.",
+    source: "article.output.text",
+  });
+});
+
+test("extractAnswerText falls back to partial output before history", () => {
+  const article = {
+    id: "00000000-0000-4000-8000-000000000002",
+    status: "running",
+    partial_output: {
+      text: "Synthetic partial answer.",
+    },
+    inputs: {
+      history: [
+        {
+          outputText: "Synthetic history fallback.",
+        },
+      ],
+    },
+  };
+
+  const extracted = extractAnswerText(article);
+
+  assert.deepEqual(extracted, {
+    text: "Synthetic partial answer.",
+    source: "article.partial_output.text",
+  });
+});
+
+test("extractAnswerText uses latest history only when current output is absent", () => {
+  const article = {
+    id: "00000000-0000-4000-8000-000000000003",
+    status: "success",
+    inputs: {
+      history: [
+        {
+          outputText: "Older synthetic history answer.",
+        },
+        {
+          outputText: "Latest synthetic history answer.",
+        },
+      ],
+    },
+  };
+
+  const extracted = extractAnswerText(article);
+
+  assert.deepEqual(extracted, {
+    text: "Latest synthetic history answer.",
+    source: "inputs.history.outputText",
+  });
+});
+
+test("extractAnswerText returns null for empty article payload", () => {
+  assert.equal(extractAnswerText({ status: "running" }), null);
+});
+
+test("getArticleStatusInfo classifies pending and complete statuses", () => {
+  assert.deepEqual(getArticleStatusInfo({ status: "running" }), {
+    status: "running",
+    is_complete: false,
+  });
+  assert.deepEqual(getArticleStatusInfo({ status: "success" }), {
+    status: "success",
+    is_complete: true,
+  });
+  assert.deepEqual(getArticleStatusInfo({}), {
+    status: null,
+    is_complete: false,
+  });
+});
+
+test("normalizeArticleResult exposes stable fields without hiding raw article", () => {
+  const article = {
+    id: "00000000-0000-4000-8000-000000000004",
+    status: "success",
+    inputs: {
+      question: "Synthetic question?",
+    },
+    output: {
+      text: "Synthetic answer.",
+    },
+  };
+
+  const normalized = normalizeArticleResult(article);
+
+  assert.equal(normalized.article_id, "00000000-0000-4000-8000-000000000004");
+  assert.equal(normalized.status, "success");
+  assert.equal(normalized.is_complete, true);
+  assert.equal(normalized.question, "Synthetic question?");
+  assert.equal(normalized.answer_text, "Synthetic answer.");
+  assert.equal(normalized.answer_source, "article.output.text");
+  assert.equal(normalized.article, article);
+});

--- a/tests/mcp-contract.test.ts
+++ b/tests/mcp-contract.test.ts
@@ -1,0 +1,63 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { ListPromptsResultSchema, ListToolsResultSchema } from "@modelcontextprotocol/sdk/types.js";
+
+test("MCP server exposes agent instructions and expected tools", async () => {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["--import", "tsx", "src/server.ts"],
+    cwd: process.cwd(),
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "contract-test", version: "1.0.0" });
+
+  await client.connect(transport);
+  try {
+    const instructions = client.getInstructions() ?? "";
+    assert.match(instructions, /oe_auth_status/);
+    assert.match(instructions, /wait_for_completion=false/);
+    assert.match(instructions, /oe_article_wait/);
+    assert.match(instructions, /original_article_id/);
+    assert.match(instructions, /storage-state/i);
+
+    const tools = await client.request(
+      { method: "tools/list", params: {} },
+      ListToolsResultSchema,
+    );
+    const byName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+
+    for (const name of [
+      "oe_auth_status",
+      "oe_history_list",
+      "oe_article_get",
+      "oe_article_wait",
+      "oe_ask",
+    ]) {
+      assert.ok(byName.has(name), `expected tool ${name}`);
+    }
+
+    assert.equal(byName.get("oe_auth_status")?.annotations?.readOnlyHint, true);
+    assert.equal(byName.get("oe_history_list")?.annotations?.readOnlyHint, true);
+    assert.equal(byName.get("oe_article_get")?.annotations?.readOnlyHint, true);
+    assert.equal(byName.get("oe_article_wait")?.annotations?.readOnlyHint, true);
+    assert.equal(byName.get("oe_ask")?.annotations?.readOnlyHint, false);
+
+    assert.match(byName.get("oe_ask")?.description ?? "", /wait_for_completion=false/);
+    assert.match(byName.get("oe_article_wait")?.description ?? "", /long research questions/);
+
+    const prompts = await client.request(
+      { method: "prompts/list", params: {} },
+      ListPromptsResultSchema,
+    );
+    const workflowPrompt = prompts.prompts.find(
+      (prompt) => prompt.name === "openevidence_research_workflow",
+    );
+    assert.ok(workflowPrompt);
+    assert.match(workflowPrompt.description ?? "", /non-blocking ask/);
+  } finally {
+    await transport.close();
+  }
+});


### PR DESCRIPTION
## Summary
- add synthetic tests for OpenEvidence article answer extraction and MCP contract metadata
- fix answer extraction so current `article.output` wins over stale `inputs.history` fallback
- add normalized article fields, `oe_article_wait`, MCP server instructions, tool annotations, and a reusable workflow prompt
- document the non-blocking long-question flow and privacy-safe agent usage

## Verification
- `npm test` passed: 7 tests
- `npm run build` passed
- `npm run check` passed
- `npm audit --audit-level=moderate` passed with 0 vulnerabilities
- built MCP contract smoke passed: instructions present; tools exposed: `oe_auth_status`, `oe_history_list`, `oe_article_get`, `oe_article_wait`, `oe_ask`; prompt exposed: `openevidence_research_workflow`
- `npm run smoke` did not authenticate locally: OpenEvidence `/api/auth/me` returned non-JSON HTML with status 200, now reported safely as unauthenticated without dumping response content

## Privacy
- tests use synthetic payloads only
- no real OpenEvidence article IDs, questions, answers, cookies, storage-state, account metadata, or patient data were added


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced setup and validation instructions with expanded tool coverage
  * Added workflow guidance for optimal tool usage and handling long-running queries
  * Updated troubleshooting recommendations for non-blocking query patterns

* **Tests**
  * Introduced comprehensive test suite for answer normalization and tool contract validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bakhtiersizhaev/openevidence-mcp/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->