### PR TITLE
fix: route oe_ask through local browser companion

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,12 +29,13 @@ Available checks:
 ```bash
 npm run build
 npm run check
+npm test
 npm run smoke
 ```
 
 `npm run smoke` requires a valid local OpenEvidence session. Run `npm run login` first if needed.
 
-There is currently no `npm test` or `npm run lint` script. If a PR cannot run one of the available checks, explain why.
+There is currently no `npm run lint` script. If a PR cannot run one of the available checks, explain why.
 
 ## Commit Convention
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ No official OpenEvidence API token is required.
 - It does not provide medical advice or replace clinical judgment.
 - It does not bypass authentication, paywalls, or access controls.
 - It does not collect credentials.
-- It does not send your browser session state anywhere except to OpenEvidence through local Playwright requests.
+- It does not send your browser session state anywhere except to OpenEvidence through local requests from your machine.
 - It should not be used for patient-specific diagnosis or treatment decisions without appropriate human review.
 
 ## Who it is for
@@ -86,8 +86,8 @@ Other MCP-compatible hosts may work as well, but the examples in this repository
 | Tool | Purpose | Auth required | Side effects |
 | --- | --- | --- | --- |
 | `oe_auth_status` | Checks whether the saved OpenEvidence browser session is authenticated. | Yes, saved session file must exist. | None. |
-| `oe_history_list` | Lists prior OpenEvidence articles/questions with optional pagination and search. | Yes. | None. |
-| `oe_article_get` | Fetches an article by ID and returns normalized fields (`status`, `is_complete`, `question`, `answer_text`) plus the raw payload. | Yes. | None. |
+| `oe_history_list` | Lists prior OpenEvidence articles with optional pagination and search. Returns a privacy-reduced list unless `include_raw=true` is explicitly requested. | Yes. | None. |
+| `oe_article_get` | Fetches an article by ID and returns normalized fields (`status`, `is_complete`, `question`, `answer_text`). Raw payload is opt-in with `include_raw=true`. | Yes. | None. |
 | `oe_article_wait` | Waits for an existing article ID to complete; useful after non-blocking `oe_ask`. | Yes. | None. |
 | `oe_ask` | Creates an OpenEvidence research question and optionally waits for the article to complete. | Yes. | Creates a question/article in your OpenEvidence account. |
 
@@ -110,6 +110,7 @@ Related commands:
 | --- | --- |
 | `npm run login` | Opens a local browser so you can sign in and save reusable session state. |
 | `npm run login:browser` | Opens system Chrome/Edge for Google SSO cases where Playwright login is blocked as unsafe. |
+| `npm run login:companion` | Opens a normal Chrome/Edge profile for the experimental local companion write path used by `oe_ask`. |
 | `npm run smoke` | Verifies auth and basic OpenEvidence connectivity. |
 
 ## Requirements
@@ -189,7 +190,23 @@ If Google sign-in says the browser or app may not be secure, use the system-brow
 npm run login:browser
 ```
 
-This opens Chrome or Edge with a local OpenEvidence MCP profile. Complete login in that browser, return to the terminal, and press Enter. The script saves local session state and verifies `/api/auth/me`.
+This opens Chrome or Edge with a local OpenEvidence MCP profile. Complete login in that browser, return to the terminal, and press Enter. The script saves local session state and checks for an authenticated browser cookie. Run `npm run smoke` afterward for the API connectivity check.
+
+The browser window is only for the manual login flow. Read-only MCP tool calls run as local stdio requests. The experimental `oe_ask` companion path may start a minimized local browser using the saved companion profile; it does not expose a public network service.
+
+### Experimental companion flow for `oe_ask`
+
+OpenEvidence may reject direct article-creation requests from a Node.js HTTP client even when read-only requests succeed. The current development branch includes a local browser companion for testing `oe_ask` through the normal authenticated OpenEvidence web interface.
+
+During development, load the unpacked companion extension and create its local browser profile:
+
+```powershell
+$env:OE_MCP_COMPANION_BROWSER = "edge"
+$env:OE_MCP_COMPANION_DEV_EXTENSION = "true"
+npm run login:companion
+```
+
+On macOS, use `chrome` or `edge` for `OE_MCP_COMPANION_BROWSER`. The unpacked-extension flow is intended for local UAT until a stable installation path is packaged. See [`docs/COMPANION_UAT.md`](docs/COMPANION_UAT.md).
 
 Do not share storage-state files, cookies, screenshots with private account data, or patient-identifiable information.
 
@@ -295,6 +312,7 @@ Common fixes:
 - Windows path issues: escape backslashes in JSON/TOML or use full absolute paths.
 - Node errors: confirm `node --version` is 20 or newer.
 - OpenEvidence UI/API changed: open an issue with sanitized logs and no private account or patient data.
+- `oe_ask` returns an upstream browser-protection `403`: read-only tools may still work. Test the experimental local companion path described above and include sanitized results when filing an issue.
 
 ## Roadmap
 

--- a/docs/AGENT_INSTALL_PROMPT.md
+++ b/docs/AGENT_INSTALL_PROMPT.md
@@ -37,6 +37,7 @@ Steps:
 8. If smoke succeeds, tell me to restart my MCP client session/app and verify the OpenEvidence tools appear.
 9. If smoke fails, summarize the error without exposing private data and suggest the next safe fix.
 10. For long OpenEvidence questions after setup, prefer `oe_ask` with `wait_for_completion=false`, then use `oe_article_wait` with the returned `article_id`.
+11. If `oe_ask` returns an upstream browser-protection `403`, report that read-only tools may still work and follow `docs/COMPANION_UAT.md` for the experimental local companion flow. Do not suggest fingerprint replay, cookie copying, stealth flags, or access-control bypasses.
 
 Expected result:
 - `npm run smoke` returns `ok: true` and `authenticated: true`.

--- a/docs/COMPANION_UAT.md
+++ b/docs/COMPANION_UAT.md
@@ -1,0 +1,69 @@
+# OpenEvidence MCP Companion UAT
+
+The local companion is an experimental write path for `oe_ask`. It submits questions through the normal authenticated OpenEvidence web interface when direct Node.js article creation is rejected upstream.
+
+The bridge binds to `127.0.0.1` only. Do not expose it over a public network. Do not paste cookies, storage-state files, private account data, patient-identifiable information, or raw upstream HTML into test reports.
+
+## Current Status
+
+- Windows 11 + Microsoft Edge: local automated integration verified.
+- macOS + Chrome or Edge: requires clean-machine UAT before merge.
+- Unpacked extension loading: development and UAT only.
+- Packaged extension installation and `companion:doctor`: required before a stable release.
+
+## Windows 11 UAT
+
+```powershell
+git checkout fix/browser-mediated-oe-ask
+git pull
+npm ci
+npm run build
+npm run check
+npm test
+npm audit --audit-level=moderate
+
+$env:OE_MCP_COMPANION_BROWSER = "edge"
+$env:OE_MCP_COMPANION_DEV_EXTENSION = "true"
+npm run login:companion
+npm run smoke
+```
+
+Complete OpenEvidence login in the opened Edge window, confirm the normal OpenEvidence page loads, close the window, and press Enter in the terminal.
+
+Then restart the MCP host with the same environment variables and test:
+
+1. `oe_auth_status` without printing private account details.
+2. `oe_ask` with `wait_for_completion=false` for a fresh general evidence question.
+3. `oe_article_wait` with the returned `article_id`.
+4. A second fresh question to confirm a new thread ID is returned.
+5. A follow-up question with `original_article_id` using only the test thread.
+
+## macOS Clean-Machine UAT
+
+```bash
+git clone https://github.com/bakhtiersizhaev/openevidence-mcp.git
+cd openevidence-mcp
+git checkout fix/browser-mediated-oe-ask
+npm ci
+npx playwright install chromium
+npm run build
+npm run check
+npm test
+npm audit --audit-level=moderate
+
+export OE_MCP_COMPANION_BROWSER=chrome
+export OE_MCP_COMPANION_DEV_EXTENSION=true
+npm run login:companion
+npm run smoke
+```
+
+Repeat the MCP-host checks from the Windows section. If Chrome does not load the unpacked extension from CLI flags on the target macOS version, document the exact result and load the repository `extension/` directory manually from the browser extension developer screen for UAT.
+
+## Expected Result
+
+- Build, check, tests, and audit pass.
+- Smoke returns `ok: true` and `authenticated: true`.
+- Fresh `oe_ask` returns a new `article_id`.
+- `oe_article_wait` returns a completed result.
+- Follow-up requests remain attached to the intended test thread.
+- No cookies, storage state, account identifiers, or unrelated history appear in logs.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -35,7 +35,9 @@ Use the system-browser login flow:
 npm run login:browser
 ```
 
-The script opens Chrome or Edge with a local OpenEvidence MCP profile. Complete OpenEvidence login in the opened browser, return to the terminal, and press Enter. It saves local session state and verifies `/api/auth/me`.
+The script opens Chrome or Edge with a local OpenEvidence MCP profile. Complete OpenEvidence login in the opened browser, return to the terminal, and press Enter. It saves local session state and checks for an authenticated browser cookie. Run `npm run smoke` afterward for the API connectivity check.
+
+This browser window is only used for manual login. Normal MCP tool calls do not open a browser window.
 
 If auto-detection chooses the wrong browser, set one of:
 
@@ -53,6 +55,28 @@ npm run login:browser
 ```
 
 Do not use stealth flags, cookie-copying browser extensions, or instructions that bypass Google, OpenEvidence, institution, regional, or account controls.
+
+## `oe_ask` Returns an Upstream Browser-Protection `403`
+
+OpenEvidence may accept auth and read-only history requests while rejecting direct article creation with an upstream browser-protection response. In this state:
+
+- `npm run smoke` may still pass;
+- `oe_auth_status`, `oe_history_list`, and existing article reads may still work;
+- the experimental local companion write path should be tested.
+
+This is not fixed by repeatedly logging in, switching VPN endpoints, copying cookies, adding stealth flags, or replaying browser fingerprint values. Do not post the returned HTML, cookies, storage state, or account details in an issue.
+
+For local development and UAT, use a normal browser profile with the unpacked companion extension:
+
+```powershell
+$env:OE_MCP_COMPANION_BROWSER = "edge"
+$env:OE_MCP_COMPANION_DEV_EXTENSION = "true"
+npm run login:companion
+```
+
+The companion bridge binds to `127.0.0.1` only and submits the question through the normal authenticated OpenEvidence web interface. It may start a minimized local browser for `oe_ask`; it does not require CDP. See [`COMPANION_UAT.md`](COMPANION_UAT.md).
+
+Open an issue with sanitized logs and link to any existing upstream-protection report if the companion flow fails. Do not post cookies, storage state, raw upstream HTML, or account details.
 
 ## Playwright Browser Install Error
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,81 @@
+const BRIDGE_URL = "http://127.0.0.1:47831";
+const POLL_INTERVAL_MS = 750;
+let processing = false;
+let lastArticlePostStatus = null;
+
+chrome.webRequest.onCompleted.addListener(
+  (details) => {
+    if (details.method === "POST") lastArticlePostStatus = details.statusCode;
+  },
+  { urls: ["https://www.openevidence.com/api/article"] },
+);
+
+async function poll() {
+  if (processing) return;
+  processing = true;
+  try {
+    const response = await fetch(`${BRIDGE_URL}/v1/next`, { cache: "no-store" });
+    if (response.status === 204) return;
+    if (!response.ok) return;
+    const job = await response.json();
+    const tab = await getOrCreateOpenEvidenceTab(job.original_article_id);
+    const result = await sendToTab(tab.id, job);
+    await postResult(job.job_id, result);
+  } catch {
+    // The MCP bridge is intentionally absent when no oe_ask call is active.
+  } finally {
+    processing = false;
+  }
+}
+
+async function getOrCreateOpenEvidenceTab(originalArticleId) {
+  const targetUrl = originalArticleId
+    ? `https://www.openevidence.com/ask/${encodeURIComponent(originalArticleId)}`
+    : "https://www.openevidence.com/";
+  const tabs = await chrome.tabs.query({ url: "https://www.openevidence.com/*" });
+  if (tabs[0]?.id) {
+    if (tabs[0].url !== targetUrl) {
+      return chrome.tabs.update(tabs[0].id, { url: targetUrl, active: false });
+    }
+    return tabs[0];
+  }
+  return chrome.tabs.create({ url: targetUrl, active: false });
+}
+
+async function sendToTab(tabId, job) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      return await chrome.tabs.sendMessage(tabId, {
+        type: "openevidence-mcp-submit",
+        job_id: job.job_id,
+        question: job.question,
+        original_article_id: job.original_article_id,
+      });
+    } catch {
+      await sleep(500);
+    }
+  }
+  return { ok: false, error: "OpenEvidence page did not become ready." };
+}
+
+async function postResult(jobId, result) {
+  await fetch(`${BRIDGE_URL}/v1/result`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ job_id: jobId, ...result }),
+  });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+setInterval(poll, POLL_INTERVAL_MS);
+void poll();
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message?.type === "openevidence-mcp-poll") void poll();
+  if (message?.type === "openevidence-mcp-last-post-status") {
+    return Promise.resolve({ status: lastArticlePostStatus });
+  }
+});

--- a/extension/content.js
+++ b/extension/content.js
@@ -1,0 +1,74 @@
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message?.type !== "openevidence-mcp-submit") return;
+  void submitQuestion(message.question, message.original_article_id).then(sendResponse);
+  return true;
+});
+
+async function submitQuestion(question, originalArticleId) {
+  try {
+    const previousArticleId = getArticleIdFromLocation();
+    const input = await waitForElement('textarea[aria-label="Ask a medical question"]', 20_000);
+    setTextareaValue(input, question);
+    const submit = await waitForElement('button[aria-label="Submit question"]', 10_000);
+    submit.click();
+    const articleId = await waitForNewArticleId(previousArticleId ?? originalArticleId, 45_000);
+    const post = await chrome.runtime
+      .sendMessage({ type: "openevidence-mcp-last-post-status" })
+      .catch(() => ({ status: null }));
+    return articleId
+      ? { ok: true, article_id: articleId }
+      : {
+          ok: false,
+          error: Number.isInteger(post?.status)
+            ? `OpenEvidence UI submit did not open a research thread (status ${post.status}).`
+            : "OpenEvidence UI submit did not open a research thread and no article POST was observed.",
+        };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+function setTextareaValue(textarea, value) {
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(textarea, value);
+  textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  textarea.dispatchEvent(new Event("change", { bubbles: true }));
+}
+
+async function waitForElement(selector, timeoutMs) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const element = document.querySelector(selector);
+    if (element instanceof HTMLElement && !element.hasAttribute("disabled")) return element;
+    await sleep(250);
+  }
+  throw new Error(`OpenEvidence UI element not found: ${selector}`);
+}
+
+async function waitForNewArticleId(previousArticleId, timeoutMs) {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const articleId = getArticleIdFromLocation();
+    if (articleId && articleId !== previousArticleId) return articleId;
+    await sleep(250);
+  }
+  return null;
+}
+
+function getArticleIdFromLocation() {
+  return location.pathname.match(/\/ask\/([0-9a-f-]{36})(?:\/|$)/i)?.[1] ?? null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function wakeBackgroundWorker() {
+  void chrome.runtime.sendMessage({ type: "openevidence-mcp-poll" }).catch(() => undefined);
+}
+
+setInterval(wakeBackgroundWorker, 750);
+void wakeBackgroundWorker();

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,21 @@
+{
+  "manifest_version": 3,
+  "name": "OpenEvidence MCP Local Companion",
+  "version": "0.1.0",
+  "description": "Local companion for submitting OpenEvidence MCP research questions through the authenticated OpenEvidence web interface.",
+  "permissions": ["tabs", "webRequest"],
+  "host_permissions": [
+    "https://www.openevidence.com/*",
+    "http://127.0.0.1/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://www.openevidence.com/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1410,9 +1410,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "start": "node dist/server.js",
     "login": "tsx src/login.ts",
     "login:browser": "tsx src/login-browser.ts",
+    "login:companion": "tsx src/login-companion.ts",
     "check": "tsc -p tsconfig.json --noEmit",
     "test": "node --import tsx --test \"tests/**/*.test.ts\"",
     "smoke": "tsx src/smoke.ts"
   },
   "files": [
     "dist/",
+    "extension/",
     "scripts/",
     "examples/",
     "docs/AGENT_INSTALL_PROMPT.md",

--- a/src/companion-bridge.ts
+++ b/src/companion-bridge.ts
@@ -1,0 +1,191 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
+import { fileURLToPath } from "node:url";
+
+import type { AppConfig } from "./config.js";
+import { findSystemBrowser } from "./system-browser.js";
+
+const DEFAULT_PORT = 47_831;
+const BODY_LIMIT_BYTES = 16_384;
+
+interface CompanionJob {
+  job_id: string;
+  question: string;
+  original_article_id?: string;
+}
+
+interface CompanionResult {
+  ok: boolean;
+  article_id?: string;
+  error?: string;
+}
+
+export class CompanionBridge {
+  private server: Server | null = null;
+  private browser: ChildProcess | null = null;
+  private pendingJob: CompanionJob | null = null;
+  private resolvePending: ((result: CompanionResult) => void) | null = null;
+  private polls = 0;
+  private jobsDelivered = 0;
+  private resultsReceived = 0;
+
+  constructor(private readonly config: AppConfig) {}
+
+  async submitQuestion(question: string, originalArticleId?: string): Promise<string> {
+    if (this.pendingJob) {
+      throw new Error("Another oe_ask request is already pending.");
+    }
+    await this.ensureStarted();
+    const job: CompanionJob = {
+      job_id: randomUUID(),
+      question,
+      original_article_id: originalArticleId,
+    };
+    this.pendingJob = job;
+
+    const result = await new Promise<CompanionResult>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.clearPending();
+        resolve({
+          ok: false,
+          error:
+            "Timed out waiting for the local OpenEvidence companion. Confirm the companion extension is installed in the selected browser profile, run `npm run login:companion`, and retry.",
+        });
+      }, 60_000);
+      this.resolvePending = (value) => {
+        clearTimeout(timeout);
+        this.clearPending();
+        resolve(value);
+      };
+    });
+
+    if (!result.ok || !result.article_id) {
+      throw new Error(result.error ?? "OpenEvidence companion did not return a research thread id.");
+    }
+    return result.article_id;
+  }
+
+  async close(): Promise<void> {
+    this.server?.closeAllConnections();
+    await new Promise<void>((resolve) => this.server?.close(() => resolve()) ?? resolve());
+    this.server = null;
+    this.browser?.kill();
+    this.browser = null;
+    this.clearPending();
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (!this.server) {
+      this.server = createServer((req, res) => void this.handleRequest(req, res));
+      await new Promise<void>((resolve, reject) => {
+        this.server!.once("error", reject);
+        this.server!.listen(resolveBridgePort(), "127.0.0.1", () => resolve());
+      });
+    }
+    if (!this.browser || this.browser.exitCode !== null) {
+      this.browser = launchCompanionBrowser(this.config);
+    }
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    if (req.method === "OPTIONS") {
+      return send(res, 204);
+    }
+    if (req.method === "GET" && req.url === "/v1/next") {
+      this.polls += 1;
+      if (!this.pendingJob) return send(res, 204);
+      this.jobsDelivered += 1;
+      return sendJson(res, 200, this.pendingJob);
+    }
+    if (req.method === "GET" && req.url === "/v1/status") {
+      return sendJson(res, 200, {
+        polls: this.polls,
+        jobs_delivered: this.jobsDelivered,
+        results_received: this.resultsReceived,
+        pending_job: Boolean(this.pendingJob),
+      });
+    }
+    if (req.method === "POST" && req.url === "/v1/result") {
+      const body = await readJsonBody(req);
+      if (!body || body.job_id !== this.pendingJob?.job_id) return send(res, 409);
+      this.resultsReceived += 1;
+      const articleId = typeof body.article_id === "string" ? body.article_id : undefined;
+      const error = typeof body.error === "string" ? body.error.slice(0, 300) : undefined;
+      this.resolvePending?.({ ok: body.ok === true, article_id: articleId, error });
+      return send(res, 204);
+    }
+    return send(res, 404);
+  }
+
+  private clearPending(): void {
+    this.pendingJob = null;
+    this.resolvePending = null;
+  }
+}
+
+function launchCompanionBrowser(config: AppConfig): ChildProcess {
+  const selected = findSystemBrowser(process.env.OE_MCP_COMPANION_BROWSER ?? "");
+  const extensionDir = fileURLToPath(new URL("../extension/", import.meta.url));
+  const loadDevelopmentExtension = process.env.OE_MCP_COMPANION_DEV_EXTENSION === "true";
+  return spawn(
+    selected.executablePath,
+    [
+      `--user-data-dir=${config.userDataDir}`,
+      ...(loadDevelopmentExtension
+        ? [`--disable-extensions-except=${extensionDir}`, `--load-extension=${extensionDir}`]
+        : []),
+      "--no-first-run",
+      "--no-default-browser-check",
+      "--start-minimized",
+      "--window-position=-32000,-32000",
+      config.baseUrl,
+    ],
+    { detached: false, stdio: "ignore", windowsHide: true },
+  );
+}
+
+function resolveBridgePort(): number {
+  const port = Number.parseInt(process.env.OE_MCP_COMPANION_PORT ?? String(DEFAULT_PORT), 10);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("OE_MCP_COMPANION_PORT must be a valid TCP port.");
+  }
+  return port;
+}
+
+async function readJsonBody(req: IncomingMessage): Promise<Record<string, unknown> | null> {
+  const chunks: Buffer[] = [];
+  let length = 0;
+  for await (const chunk of req) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    length += buffer.length;
+    if (length > BODY_LIMIT_BYTES) return null;
+    chunks.push(buffer);
+  }
+  try {
+    const parsed = JSON.parse(Buffer.concat(chunks).toString("utf8")) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function send(res: ServerResponse, status: number): void {
+  res.writeHead(status, corsHeaders());
+  res.end();
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { ...corsHeaders(), "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function corsHeaders(): Record<string, string> {
+  return {
+    "access-control-allow-origin": "https://www.openevidence.com",
+    "access-control-allow-methods": "GET, POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+  };
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,17 @@
+export function classifyWriteFailure(status: number, contentType: string, text: string): string {
+  const lower = text.toLowerCase();
+  const looksLikeProtectionBlock =
+    status === 403 &&
+    (contentType.toLowerCase().includes("text/html") ||
+      lower.includes("enable js") ||
+      lower.includes("disable any ad blocker"));
+
+  if (looksLikeProtectionBlock) {
+    return [
+      "OpenEvidence blocked article creation with an upstream browser-protection response (403).",
+      "The saved session may still support read-only tools, but oe_ask is unavailable through the current web-session transport.",
+      "Do not paste the HTML response, cookies, session state, or account details into public issues.",
+    ].join(" ");
+  }
+  return `POST request failed with status ${status}.`;
+}

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,32 @@
+export function sanitizeHistoryPayload(payload: unknown): Record<string, unknown> {
+  const record = asRecord(payload);
+  const results = Array.isArray(record.results) ? record.results : [];
+  return {
+    has_next: Boolean(record.next),
+    has_previous: Boolean(record.previous),
+    results: results.map(sanitizeHistoryItem),
+  };
+}
+
+function sanitizeHistoryItem(item: unknown): Record<string, unknown> {
+  const record = asRecord(item);
+  return {
+    article_id: stringOrNull(record.id),
+    status: stringOrNull(record.status),
+    title: stringOrNull(record.title),
+    datetime_created: stringOrNull(record.datetime_created),
+    article_type: stringOrNull(record.article_type),
+    access_level: stringOrNull(record.access_level),
+  };
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/src/login-browser.ts
+++ b/src/login-browser.ts
@@ -2,9 +2,7 @@
 import "dotenv/config";
 
 import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
-import { homedir, platform } from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
@@ -12,18 +10,14 @@ import { stdin as input, stdout as output } from "node:process";
 import { chromium, type BrowserContext } from "playwright";
 
 import { ensureConfigDirs, resolveConfig } from "./config.js";
-
-interface BrowserChoice {
-  name: string;
-  executablePath: string;
-}
+import { findSystemBrowser } from "./system-browser.js";
 
 async function main() {
   const config = resolveConfig();
   ensureConfigDirs(config);
 
   const port = parseInt(process.env.OE_MCP_BROWSER_DEBUG_PORT ?? "9222", 10);
-  const browser = findBrowser();
+  const browser = findSystemBrowser();
   const loginUrl = `${config.baseUrl}/login`;
 
   await mkdir(config.userDataDir, { recursive: true });
@@ -62,94 +56,6 @@ async function main() {
   }
 }
 
-function findBrowser(): BrowserChoice {
-  const explicitPath = process.env.OE_MCP_BROWSER_PATH;
-  if (explicitPath) {
-    if (!existsSync(explicitPath)) {
-      throw new Error(`OE_MCP_BROWSER_PATH does not exist: ${explicitPath}`);
-    }
-    return { name: "custom browser", executablePath: explicitPath };
-  }
-
-  const preferred = (process.env.OE_MCP_BROWSER ?? "").toLowerCase();
-  const candidates = getBrowserCandidates();
-  const ordered = preferred
-    ? [
-        ...candidates.filter((candidate) => candidate.name.toLowerCase().includes(preferred)),
-        ...candidates.filter((candidate) => !candidate.name.toLowerCase().includes(preferred)),
-      ]
-    : candidates;
-
-  const found = ordered.find((candidate) => existsSync(candidate.executablePath));
-  if (!found) {
-    throw new Error(
-      [
-        "Could not find Chrome, Edge, or Chromium.",
-        "Install one of them or set OE_MCP_BROWSER_PATH to the browser executable.",
-      ].join(" "),
-    );
-  }
-
-  return found;
-}
-
-function getBrowserCandidates(): BrowserChoice[] {
-  const os = platform();
-  if (os === "win32") {
-    const local = process.env.LOCALAPPDATA ?? "";
-    const programFiles = process.env.ProgramFiles ?? "";
-    const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "";
-    return [
-      {
-        name: "Google Chrome",
-        executablePath: path.join(programFiles, "Google", "Chrome", "Application", "chrome.exe"),
-      },
-      {
-        name: "Google Chrome",
-        executablePath: path.join(programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
-      },
-      {
-        name: "Google Chrome",
-        executablePath: path.join(local, "Google", "Chrome", "Application", "chrome.exe"),
-      },
-      {
-        name: "Microsoft Edge",
-        executablePath: path.join(programFiles, "Microsoft", "Edge", "Application", "msedge.exe"),
-      },
-      {
-        name: "Microsoft Edge",
-        executablePath: path.join(programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
-      },
-    ];
-  }
-
-  if (os === "darwin") {
-    return [
-      {
-        name: "Google Chrome",
-        executablePath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-      },
-      {
-        name: "Microsoft Edge",
-        executablePath: "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
-      },
-      {
-        name: "Chromium",
-        executablePath: "/Applications/Chromium.app/Contents/MacOS/Chromium",
-      },
-    ];
-  }
-
-  return [
-    { name: "Google Chrome", executablePath: "/usr/bin/google-chrome" },
-    { name: "Google Chrome", executablePath: "/usr/bin/google-chrome-stable" },
-    { name: "Microsoft Edge", executablePath: "/usr/bin/microsoft-edge" },
-    { name: "Microsoft Edge", executablePath: "/usr/bin/microsoft-edge-stable" },
-    { name: "Chromium", executablePath: "/usr/bin/chromium" },
-    { name: "Chromium", executablePath: "/usr/bin/chromium-browser" },
-  ];
-}
-
 function launchBrowser(
   executablePath: string,
   userDataDir: string,
@@ -174,7 +80,7 @@ async function saveStorageStateFromBrowser(
   port: number,
   authStatePath: string,
 ): Promise<boolean> {
-  const browser = await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+  const browser = await connectToBrowserWithRetry(port);
   try {
     const context = browser.contexts()[0];
     if (!context) {
@@ -188,6 +94,19 @@ async function saveStorageStateFromBrowser(
   } finally {
     await browser.close();
   }
+}
+
+async function connectToBrowserWithRetry(port: number) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 40; attempt += 1) {
+    try {
+      return await chromium.connectOverCDP(`http://127.0.0.1:${port}`);
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  throw lastError;
 }
 
 async function waitForEnter(prompt: string): Promise<void> {

--- a/src/login-companion.ts
+++ b/src/login-companion.ts
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+import "dotenv/config";
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdir } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { createInterface } from "node:readline/promises";
+import { stdin as input, stdout as output } from "node:process";
+
+import { ensureConfigDirs, resolveConfig } from "./config.js";
+import { findSystemBrowser } from "./system-browser.js";
+
+async function main() {
+  const config = resolveConfig();
+  ensureConfigDirs(config);
+
+  const browser = findSystemBrowser(process.env.OE_MCP_COMPANION_BROWSER ?? "");
+  const loginUrl = `${config.baseUrl}/login`;
+  const extensionDir = fileURLToPath(new URL("../extension/", import.meta.url));
+
+  await mkdir(config.userDataDir, { recursive: true });
+
+  output.write(`[openevidence-mcp] launching ${browser.name} for companion login...\n`);
+  output.write(`[openevidence-mcp] login URL: ${loginUrl}\n`);
+  output.write(`[openevidence-mcp] profile dir: ${config.userDataDir}\n\n`);
+
+  const child = launchBrowser(browser.executablePath, config.userDataDir, extensionDir, loginUrl);
+
+  try {
+    output.write(
+      [
+        "1) Complete OpenEvidence login in the opened browser window.",
+        "2) Confirm that the normal OpenEvidence page loads while signed in.",
+        "3) Close the companion browser window so its local profile is flushed to disk.",
+        "4) Return here and press Enter.",
+        "",
+        "This companion login stores the browser profile locally. It does not use CDP,",
+        "export cookies, or require a visible browser window during every MCP request.",
+        "",
+      ].join("\n"),
+    );
+
+    await waitForEnter("Press Enter after closing the companion browser window...");
+    output.write(`[openevidence-mcp] companion browser profile is ready.\n`);
+    output.write(`[openevidence-mcp] next: run npm run smoke, then test oe_ask.\n`);
+  } finally {
+    child.kill();
+  }
+}
+
+function launchBrowser(
+  executablePath: string,
+  userDataDir: string,
+  extensionDir: string,
+  loginUrl: string,
+): ChildProcess {
+  const args = [
+    `--user-data-dir=${userDataDir}`,
+    "--no-first-run",
+    "--no-default-browser-check",
+  ];
+
+  if (process.env.OE_MCP_COMPANION_DEV_EXTENSION === "true") {
+    args.push(`--disable-extensions-except=${extensionDir}`, `--load-extension=${extensionDir}`);
+  }
+
+  args.push(loginUrl);
+
+  return spawn(executablePath, args, {
+    detached: false,
+    stdio: "ignore",
+  });
+}
+
+async function waitForEnter(prompt: string): Promise<void> {
+  const rl = createInterface({ input, output });
+  try {
+    await rl.question(`${prompt}\n`);
+  } finally {
+    rl.close();
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : "Unknown error.";
+  output.write(`[openevidence-mcp] failed: ${message.slice(0, 300)}\n`);
+  output.write(
+    [
+      "",
+      "Try:",
+      "- close other Chrome/Edge windows that use the companion profile;",
+      "- set OE_MCP_COMPANION_BROWSER=edge or chrome to choose a browser;",
+      "- set OE_MCP_BROWSER_PATH to a browser executable if auto-detection fails.",
+      "",
+    ].join("\n"),
+  );
+  process.exit(1);
+});

--- a/src/openevidence-client.ts
+++ b/src/openevidence-client.ts
@@ -3,7 +3,9 @@ import { constants } from "node:fs";
 import { request, type APIRequestContext } from "playwright";
 
 import { extractAnswerText as extractArticleAnswerText } from "./article.js";
+import { CompanionBridge } from "./companion-bridge.js";
 import type { AppConfig } from "./config.js";
+import { classifyWriteFailure } from "./errors.js";
 import type { AuthStatusResult, OpenEvidenceAskRequest, WaitOptions } from "./types.js";
 
 const DEFAULT_ARTICLE_TYPE = "Ask OpenEvidence Light with citations";
@@ -11,6 +13,7 @@ const PENDING_STATUSES = new Set(["queued", "pending", "processing", "running", 
 
 export class OpenEvidenceClient {
   private ctx: APIRequestContext | null = null;
+  private companion: CompanionBridge | null = null;
 
   constructor(private readonly config: AppConfig) {}
 
@@ -26,6 +29,10 @@ export class OpenEvidenceClient {
     if (this.ctx) {
       await this.ctx.dispose();
       this.ctx = null;
+    }
+    if (this.companion) {
+      await this.companion.close();
+      this.companion = null;
     }
   }
 
@@ -73,23 +80,16 @@ export class OpenEvidenceClient {
   }
 
   async ask(payload: OpenEvidenceAskRequest): Promise<Record<string, unknown>> {
-    const body: Record<string, unknown> = {
+    this.companion ??= new CompanionBridge(this.config);
+    const articleId = await this.companion.submitQuestion(
+      payload.question,
+      payload.originalArticleId,
+    );
+    return {
+      id: articleId,
+      status: "pending",
       article_type: payload.articleType ?? DEFAULT_ARTICLE_TYPE,
-      inputs: {
-        variant_configuration_file: payload.variantConfigurationFile ?? "prod",
-        attachments: [],
-        question: payload.question,
-        use_gatekeeper: true,
-      },
-      personalization_enabled: payload.personalizationEnabled ?? false,
-      disable_caching: payload.disableCaching ?? false,
     };
-
-    if (payload.originalArticleId) {
-      body.original_article = payload.originalArticleId;
-    }
-
-    return (await this.postJson("/api/article", body)) as Record<string, unknown>;
   }
 
   async waitForArticle(articleId: string, options?: WaitOptions): Promise<Record<string, unknown>> {
@@ -129,8 +129,9 @@ export class OpenEvidenceClient {
     const res = await this.postWithRetry(url, body, 2);
     const status = res.status();
     if (status !== 200 && status !== 201) {
+      const contentType = res.headers()["content-type"] ?? "";
       const text = await res.text();
-      throw new Error(`POST ${url} failed: ${status} ${text.slice(0, 400)}`);
+      throw new Error(classifyWriteFailure(status, contentType, text));
     }
     return res.json();
   }
@@ -181,7 +182,6 @@ async function readJsonObject(res: { headers(): Record<string, string>; json(): 
   } catch {
     return null;
   }
-
   return null;
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { normalizeArticleResult } from "./article.js";
 import { ensureConfigDirs, resolveConfig } from "./config.js";
+import { sanitizeHistoryPayload } from "./history.js";
 import { extractAnswerText, OpenEvidenceClient } from "./openevidence-client.js";
 import type { OpenEvidenceAskRequest } from "./types.js";
 
@@ -73,7 +74,7 @@ server.registerTool(
   async () =>
     withClient(async (client) => {
       const status = await client.getAuthStatus();
-      return ok(status);
+      return ok(sanitizeAuthStatus(status));
     }),
 );
 
@@ -82,7 +83,7 @@ server.registerTool(
   {
     title: "OpenEvidence History List",
     description:
-      "List prior OpenEvidence articles/questions from the authenticated account. Use to find recent research threads or article IDs. Inputs: limit, offset, optional search. Returns the OpenEvidence history payload. Requires authenticated session. No side effects. Can fail on expired auth, network errors, or OpenEvidence endpoint changes.",
+      "List prior OpenEvidence articles from the authenticated account. Use only when the user asks to inspect prior OpenEvidence work or needs an article_id. Inputs: limit, offset, optional search, optional include_raw=false. Returns a privacy-reduced list by default; include_raw=true may expose private prior questions and must be used only with explicit user intent. Requires authenticated session. No side effects.",
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -91,12 +92,13 @@ server.registerTool(
       limit: z.number().int().min(1).max(100).default(20).optional(),
       offset: z.number().int().min(0).default(0).optional(),
       search: z.string().max(200).optional(),
+      include_raw: z.boolean().default(false).optional(),
     }),
   },
   async (args) =>
     withClient(async (client) => {
       const data = await client.listHistory(args.limit ?? 20, args.offset ?? 0, args.search);
-      return ok(data);
+      return ok(args.include_raw ? data : sanitizeHistoryPayload(data));
     }),
 );
 
@@ -105,22 +107,24 @@ server.registerTool(
   {
     title: "OpenEvidence Article Get",
     description:
-      "Fetch a full OpenEvidence article payload by article_id. Use after history lookup or oe_ask returns an article ID. Input: article_id UUID. Returns normalized fields including status, is_complete, question, answer_text, answer_source, plus raw article data. Requires authenticated session. No side effects. Can fail on expired auth, network errors, invalid/unknown ID, or endpoint changes.",
+      "Fetch an OpenEvidence article by article_id. Use after history lookup or oe_ask returns an article ID. Inputs: article_id UUID, optional include_raw=false. Returns normalized status, question, and answer fields by default. include_raw=true may expose private thread context and must be used only with explicit user intent. Requires authenticated session. No side effects.",
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
     },
     inputSchema: z.object({
       article_id: z.string().uuid(),
+      include_raw: z.boolean().default(false).optional(),
     }),
   },
   async (args) =>
     withClient(async (client) => {
       const article = await client.getArticle(args.article_id);
-      return ok({
+      const result = {
         ...normalizeArticleResult(article),
         extracted_answer_raw: extractAnswerText(article),
-      });
+      };
+      return ok(args.include_raw ? result : omitRawArticle(result));
     }),
 );
 
@@ -129,7 +133,7 @@ server.registerTool(
   {
     title: "OpenEvidence Article Wait",
     description:
-      "Wait for an existing OpenEvidence article_id to finish, then return normalized article fields and raw article data. Use after oe_ask with wait_for_completion=false, especially for long research questions that may exceed MCP host timeouts. Inputs: article_id UUID, optional timeout_sec and poll_interval_ms. Requires authenticated session. No side effects. Can return is_complete=false on timeout.",
+      "Wait for an existing OpenEvidence article_id to finish, then return normalized fields. Use after oe_ask with wait_for_completion=false, especially for long research questions that may exceed MCP host timeouts. Inputs: article_id UUID, optional timeout_sec, poll_interval_ms, and include_raw=false. include_raw=true may expose private thread context and must be used only with explicit user intent. Requires authenticated session. No side effects.",
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -138,6 +142,7 @@ server.registerTool(
       article_id: z.string().uuid(),
       timeout_sec: z.number().int().min(5).max(900).default(180).optional(),
       poll_interval_ms: z.number().int().min(300).max(10000).default(1200).optional(),
+      include_raw: z.boolean().default(false).optional(),
     }),
   },
   async (args) =>
@@ -146,10 +151,11 @@ server.registerTool(
         timeoutMs: (args.timeout_sec ?? 180) * 1000,
         intervalMs: args.poll_interval_ms ?? config.pollIntervalMs,
       });
-      return ok({
+      const result = {
         ...normalizeArticleResult(article),
         extracted_answer_raw: extractAnswerText(article),
-      });
+      };
+      return ok(args.include_raw ? result : omitRawArticle(result));
     }),
 );
 
@@ -158,7 +164,7 @@ server.registerTool(
   {
     title: "OpenEvidence Ask",
     description:
-      "Create an OpenEvidence research question, not medical advice or patient-specific diagnosis. For long questions, prefer wait_for_completion=false and then call oe_article_wait with the returned article_id. Use original_article_id only for true follow-up continuity; omit it for fresh questions. Returns created article data, article_id, and optionally normalized completed article fields. Side effect: creates a question/article in the user's OpenEvidence account. Can fail on expired auth, network timeout, invalid follow-up ID, or endpoint changes.",
+      "Create an OpenEvidence research question, not medical advice or patient-specific diagnosis. For long questions, prefer wait_for_completion=false and then call oe_article_wait with the returned article_id. Use original_article_id only for true follow-up continuity; omit it for fresh questions. Returns privacy-reduced created article data and optionally normalized completed fields. Side effect: creates a question/article in the user's OpenEvidence account. Can fail if upstream browser protection rejects web-session automation.",
     annotations: {
       readOnlyHint: false,
       idempotentHint: false,
@@ -195,9 +201,9 @@ server.registerTool(
       const waitForCompletion = args.wait_for_completion ?? true;
       if (!waitForCompletion) {
         return ok({
-          created,
+          created: sanitizeCreatedArticle(created),
           article_id: articleId,
-          note: "Article created. Poll with oe_article_get.",
+          note: "Article created. Poll with oe_article_wait or oe_article_get.",
         });
       }
 
@@ -207,8 +213,8 @@ server.registerTool(
       });
 
       return ok({
-        created,
-        ...normalizeArticleResult(article),
+        created: sanitizeCreatedArticle(created),
+        ...omitRawArticle(normalizeArticleResult(article)),
         article_id: articleId,
         extracted_answer_raw: extractAnswerText(article),
       });
@@ -259,6 +265,39 @@ function toStructured(data: unknown): Record<string, unknown> {
     return data as Record<string, unknown>;
   }
   return { value: data };
+}
+
+function omitRawArticle<T extends { article?: unknown }>(result: T): Omit<T, "article"> {
+  const { article: _article, ...safe } = result;
+  return safe;
+}
+
+function sanitizeAuthStatus(status: {
+  authenticated: boolean;
+  statusCode: number;
+  user?: Record<string, unknown>;
+  message?: string;
+}) {
+  return {
+    authenticated: status.authenticated,
+    statusCode: status.statusCode,
+    user: {
+      present: Boolean(status.user),
+      email_present: typeof status.user?.email === "string" && status.user.email.length > 0,
+      name_present: typeof status.user?.name === "string" && status.user.name.length > 0,
+    },
+    message: status.message,
+  };
+}
+
+function sanitizeCreatedArticle(article: Record<string, unknown>) {
+  return {
+    article_id: typeof article.id === "string" ? article.id : null,
+    status: typeof article.status === "string" ? article.status : null,
+    article_type: typeof article.article_type === "string" ? article.article_type : null,
+    datetime_created:
+      typeof article.datetime_created === "string" ? article.datetime_created : null,
+  };
 }
 
 async function main() {

--- a/src/system-browser.ts
+++ b/src/system-browser.ts
@@ -1,0 +1,72 @@
+import { existsSync } from "node:fs";
+import { platform } from "node:os";
+import path from "node:path";
+
+export interface BrowserChoice {
+  name: string;
+  executablePath: string;
+}
+
+export function findSystemBrowser(defaultPreference = ""): BrowserChoice {
+  const explicitPath = process.env.OE_MCP_BROWSER_PATH;
+  if (explicitPath) {
+    if (!existsSync(explicitPath)) {
+      throw new Error(`OE_MCP_BROWSER_PATH does not exist: ${explicitPath}`);
+    }
+    return { name: "custom browser", executablePath: explicitPath };
+  }
+
+  const preferred = (process.env.OE_MCP_BROWSER ?? defaultPreference).toLowerCase();
+  const candidates = getBrowserCandidates();
+  const ordered = preferred
+    ? [
+        ...candidates.filter((candidate) => candidate.name.toLowerCase().includes(preferred)),
+        ...candidates.filter((candidate) => !candidate.name.toLowerCase().includes(preferred)),
+      ]
+    : candidates;
+
+  const found = ordered.find((candidate) => existsSync(candidate.executablePath));
+  if (!found) {
+    throw new Error(
+      "Could not find Chrome, Edge, or Chromium. Install one or set OE_MCP_BROWSER_PATH.",
+    );
+  }
+  return found;
+}
+
+function getBrowserCandidates(): BrowserChoice[] {
+  const os = platform();
+  if (os === "win32") {
+    const local = process.env.LOCALAPPDATA ?? "";
+    const programFiles = process.env.ProgramFiles ?? "";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] ?? "";
+    return [
+      browser("Google Chrome", programFiles, "Google", "Chrome", "Application", "chrome.exe"),
+      browser("Google Chrome", programFilesX86, "Google", "Chrome", "Application", "chrome.exe"),
+      browser("Google Chrome", local, "Google", "Chrome", "Application", "chrome.exe"),
+      browser("Microsoft Edge", programFiles, "Microsoft", "Edge", "Application", "msedge.exe"),
+      browser("Microsoft Edge", programFilesX86, "Microsoft", "Edge", "Application", "msedge.exe"),
+    ];
+  }
+
+  if (os === "darwin") {
+    return [
+      browser("Google Chrome", "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
+      browser("Microsoft Edge", "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge"),
+      browser("Chromium", "/Applications/Chromium.app/Contents/MacOS/Chromium"),
+    ];
+  }
+
+  return [
+    browser("Google Chrome", "/usr/bin/google-chrome"),
+    browser("Google Chrome", "/usr/bin/google-chrome-stable"),
+    browser("Microsoft Edge", "/usr/bin/microsoft-edge"),
+    browser("Microsoft Edge", "/usr/bin/microsoft-edge-stable"),
+    browser("Chromium", "/usr/bin/chromium"),
+    browser("Chromium", "/usr/bin/chromium-browser"),
+  ];
+}
+
+function browser(name: string, ...parts: string[]): BrowserChoice {
+  return { name, executablePath: path.join(...parts) };
+}

--- a/tests/history-redaction.test.ts
+++ b/tests/history-redaction.test.ts
@@ -1,0 +1,54 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { classifyWriteFailure } from "../src/errors.js";
+import { sanitizeHistoryPayload } from "../src/history.js";
+
+test("sanitizeHistoryPayload removes nested private thread context", () => {
+  const sanitized = sanitizeHistoryPayload({
+    next: "https://example.test/next",
+    previous: null,
+    results: [
+      {
+        id: "00000000-0000-4000-8000-000000000001",
+        status: "success",
+        title: "Synthetic title",
+        datetime_created: "2026-05-30T00:00:00Z",
+        article_type: "Synthetic",
+        access_level: "CREATOR_ONLY",
+        inputs: {
+          question: "Synthetic private question",
+          history: [{ input: "Synthetic nested private question" }],
+        },
+      },
+    ],
+  });
+
+  assert.deepEqual(sanitized, {
+    has_next: true,
+    has_previous: false,
+    results: [
+      {
+        article_id: "00000000-0000-4000-8000-000000000001",
+        status: "success",
+        title: "Synthetic title",
+        datetime_created: "2026-05-30T00:00:00Z",
+        article_type: "Synthetic",
+        access_level: "CREATOR_ONLY",
+      },
+    ],
+  });
+  assert.doesNotMatch(JSON.stringify(sanitized), /private question/);
+});
+
+test("classifyWriteFailure redacts upstream browser-protection HTML", () => {
+  const message = classifyWriteFailure(
+    403,
+    "text/html",
+    "<html>Please enable JS and disable any ad blocker cid=private-debug-value</html>",
+  );
+
+  assert.match(message, /browser-protection response/);
+  assert.doesNotMatch(message, /private-debug-value/);
+  assert.doesNotMatch(message, /cid=/);
+});


### PR DESCRIPTION
## Summary

Draft fix for the `oe_ask` write-path failure reported in [#19](https://github.com/bakhtiersizhaev/openevidence-mcp/issues/19) by [@leomfischer-br](https://github.com/leomfischer-br).

The report established that authentication and read-only tools remained healthy while direct Node.js article creation consistently returned an upstream `403` browser-protection response on Windows 11, regardless of re-login or IP changes.

This PR is intentionally opened as a **draft** for cross-platform UAT. Do not merge or close #19 until Windows 11 manual MCP-host testing and a clean macOS install have both passed.

## Root cause

The original `oe_ask` implementation sent `POST /api/article` from the Node.js Playwright request context. OpenEvidence can accept the saved browser session for read-only endpoints while rejecting article creation from that transport.

A separate experiment also showed that CDP-based login/export is fragile on Edge (`browserType.connectOverCDP: read ECONNRESET`). The companion login flow therefore no longer depends on CDP.

## What changed

### Local companion write path

- Added a local MV3 browser companion under `extension/`.
- Added `CompanionBridge`, bound to `127.0.0.1` only.
- Routed fresh `oe_ask` requests and follow-up requests through the normal authenticated OpenEvidence web interface.
- Reused the saved browser profile and started the companion browser minimized/off-screen for write calls.
- Required a genuinely new thread ID after submit so a previously open thread cannot be mistaken for a successful new request.
- Preserved `original_article_id` continuity for follow-up questions.

### Login flow

- Added `npm run login:companion`.
- Removed CDP export from the companion login path. The normal browser persists its own local profile.
- Kept the existing `login` and `login:browser` flows for the saved read-only session transport.
- Extracted cross-platform Chrome / Edge / Chromium discovery into `src/system-browser.ts`.

### Privacy and diagnostics

- Redacted auth status output by default.
- Made history and article raw payloads opt-in via `include_raw=true`.
- Added sanitized classification for upstream write failures so raw HTML and session details are not echoed.
- Upgraded transitive `qs` dependency in the lockfile after audit remediation.

### Tests and docs

- Added privacy-redaction and write-error tests.
- Updated MCP tool descriptions with clearer agent instructions and explicit raw-data boundaries.
- Added [`docs/COMPANION_UAT.md`](https://github.com/bakhtiersizhaev/openevidence-mcp/blob/fix/browser-mediated-oe-ask/docs/COMPANION_UAT.md) for Windows 11 and clean-machine macOS testing.
- Updated README, contributor notes, agent install prompt, and troubleshooting guidance.

## Local Windows 11 verification completed

The following passed locally on Windows 11:

```text
npm run build                         pass
npm run check                         pass
npm test                              pass (9/9)
npm audit --audit-level=moderate      pass (0 vulnerabilities)
npm run smoke                         pass (ok: true, authenticated: true)
```

Two sanitized integration checks also passed:

```text
fresh oe_ask -> new article_id -> pending
fresh oe_ask -> new article_id -> oe_article_wait -> success
```

No cookies, storage state, private account details, or unrelated OpenEvidence history are included in this PR.

## Required UAT before merge

### Windows 11

- [ ] Run the manual MCP-host flow in Codex App.
- [ ] Verify `oe_auth_status` without private account output.
- [ ] Verify fresh `oe_ask` with `wait_for_completion=false` followed by `oe_article_wait`.
- [ ] Verify a second fresh question returns a different thread ID.
- [ ] Verify one follow-up question remains attached to the intended test thread.
- [ ] Verify the minimized companion browser does not interrupt the normal workflow.

### macOS clean install

- [ ] Clone this branch on a clean macOS machine.
- [ ] Run `npm ci`, Playwright Chromium install, build, check, tests, and audit.
- [ ] Test Chrome or Edge companion-profile login from scratch.
- [ ] Verify smoke output is authenticated and redacted.
- [ ] Repeat fresh-question and follow-up MCP-host checks.
- [ ] Document whether CLI unpacked-extension loading works on the tested browser version or requires manual developer-mode loading for UAT.

## Known limitations before stable release

- Unpacked extension loading is currently a development/UAT mechanism, not a finished end-user onboarding path.
- A `companion:doctor` diagnostic command is still planned.
- The browser companion should receive a final local bridge threat review before release packaging.
- macOS behavior has not yet been verified.

## Issue

Addresses [#19](https://github.com/bakhtiersizhaev/openevidence-mcp/issues/19). Thank you to [@leomfischer-br](https://github.com/leomfischer-br) for the detailed reproduction report and the observation that the failure was isolated to `oe_ask` while authenticated read-only operations remained healthy.
