### PR TITLE
Use Chrome's modern headless mode (--headless=new) for session launch

### DIFF
--- a/src/browser-session.ts
+++ b/src/browser-session.ts
@@ -140,13 +140,19 @@ export class BrowserSession {
     const browser = findSystemBrowser();
     const isHeadless = process.env.OE_MCP_BROWSER_HEADLESS !== "0";
 
+    // Drive Chrome's modern headless mode via an explicit `--headless=new` flag
+    // rather than Playwright's legacy `--headless`, which crashes on current
+    // Chrome builds (launch exits with code 21). We keep the system Chrome so the
+    // login-session profile stays fully compatible. headless:false stops Playwright
+    // from injecting the legacy flag; Playwright still attaches over the debug pipe.
     this.context = await chromium.launchPersistentContext(this.config.userDataDir, {
       executablePath: browser.executablePath,
-      headless: isHeadless,
+      headless: false,
       viewport: isHeadless ? { width: 1280, height: 800 } : null,
       userAgent: getCleanUserAgent(),
       ignoreDefaultArgs: ["--enable-automation"],
       args: [
+        ...(isHeadless ? ["--headless=new"] : []),
         "--no-first-run",
         "--no-default-browser-check",
         "--start-minimized",


### PR DESCRIPTION
## What

`BrowserSession.launch()` uses Playwright's `headless: true`, which injects Chrome's **legacy** `--headless` flag. On current Chrome builds (150+) the legacy headless mode is deprecated and can fail to start the persistent context (launch exits early with `browserType.launchPersistentContext: Target page, context or browser has been closed`).

This switches to Chrome's modern headless mode via an explicit `--headless=new` argument, while keeping the system Chrome so the `login:session` profile stays fully compatible.

## Change

- `src/browser-session.ts`: set `headless: false` (so Playwright doesn't inject the legacy `--headless`) and pass `--headless=new` ourselves only when headless is requested. The non-headless (login/visible) path is unchanged.

## Testing

- `npm run build` && `npm run smoke` → `{ "ok": true, "authenticated": true }`, history preview + a real `oe_ask` returned a full answer with citations, all running under `--headless=new` on Chrome 150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved headless browser operation when using system Chrome.
  * Updated browser launch handling for more consistent headless-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->